### PR TITLE
replace "Verizon" with "Edgio" in cdn-features.md

### DIFF
--- a/articles/cdn/cdn-features.md
+++ b/articles/cdn/cdn-features.md
@@ -17,15 +17,15 @@ Azure Content Delivery Network (CDN) includes four products:
 
 * **Azure CDN Standard from Microsoft**
 * **Azure CDN Standard from Akamai**
-* **Azure CDN Standard from Verizon**
-* **Azure CDN Premium from Verizon**.
+* **Azure CDN Standard from Edgio**
+* **Azure CDN Premium from Edgio**.
 
 > [!IMPORTANT]
 > Azure CDN from Akamai is scheduled to be retired on October 31, 2023. You can no longer create new Azure CDN from Akamai after June 1, 2023. For more information, see [**Migrate CDN provider**](cdn-change-provider.md) for guidance on migrating to another Azure CDN provider.
 
 The following table compares the features available with each product.
 
-| **Performance features and optimizations** | **Standard Microsoft** | **Standard Akamai** | **Standard Verizon** | **Premium Verizon** |
+| **Performance features and optimizations** | **Standard Microsoft** | **Standard Akamai** | **Standard Edgio** | **Premium Edgio** |
 | --- | --- | --- | --- | --- |
 | [Dynamic site acceleration](./cdn-dynamic-site-acceleration.md)  | Offered via [Azure Front Door Service](../frontdoor/front-door-overview.md) | **&#x2713;**  | **&#x2713;** | **&#x2713;** |
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Dynamic site acceleration - adaptive image compression](./cdn-dynamic-site-acceleration.md#adaptive-image-compression-azure-cdn-from-akamai-only)  |  | **&#x2713;**  |  |  |
@@ -47,7 +47,7 @@ The following table compares the features available with each product.
 | IPv4/IPv6 dual-stack | **&#x2713;** |**&#x2713;** |**&#x2713;** |**&#x2713;** |
 | [HTTP/2 support](cdn-http2.md)  | **&#x2713;** |**&#x2713;** |**&#x2713;** |**&#x2713;** |
 ||||
- **Security** | **Standard Microsoft** | **Standard Akamai** | **Standard Verizon** | **Premium Verizon** |
+ **Security** | **Standard Microsoft** | **Standard Akamai** | **Standard Edgio** | **Premium Edgio** |
 | HTTPS support with CDN endpoint | **&#x2713;** |**&#x2713;** |**&#x2713;** |**&#x2713;** |
 | [Custom domain HTTPS](cdn-custom-ssl.md)  | **&#x2713;** | **&#x2713;**, Requires direct CNAME to enable |**&#x2713;** |**&#x2713;** |
 | [Custom domain name support](cdn-map-content-to-custom-domain.md)  | **&#x2713;** |**&#x2713;** |**&#x2713;** |**&#x2713;** |
@@ -57,16 +57,16 @@ The following table compares the features available with each product.
 | [Bring your own certificate](cdn-custom-ssl.md?tabs=option-2-enable-https-with-your-own-certificate#tlsssl-certificates) |**&#x2713;** |  | **&#x2713;** | **&#x2713;** |
 | Supported TLS Versions | TLS 1.2, TLS 1.0/1.1 - [Configurable](/rest/api/cdn/custom-domains/enable-custom-https#usermanagedhttpsparameters) | TLS 1.2 | TLS 1.2 | TLS 1.2 |
 ||||
-| **Analytics and reporting** | **Standard Microsoft** | **Standard Akamai** | **Standard Verizon** | **Premium Verizon** |
+| **Analytics and reporting** | **Standard Microsoft** | **Standard Akamai** | **Standard Edgio** | **Premium Edgio** |
 | [Azure diagnostic logs](cdn-azure-diagnostic-logs.md)  | **&#x2713;** | **&#x2713;** |**&#x2713;** |**&#x2713;** |
-| [Core reports from Verizon](cdn-analyze-usage-patterns.md)  |  | |**&#x2713;** |**&#x2713;** |
-| [Custom reports from Verizon](cdn-verizon-custom-reports.md)  |  | |**&#x2713;** |**&#x2713;** |
+| [Core reports from Edgio](cdn-analyze-usage-patterns.md)  |  | |**&#x2713;** |**&#x2713;** |
+| [Custom reports from Edgio](cdn-verizon-custom-reports.md)  |  | |**&#x2713;** |**&#x2713;** |
 | [Advanced HTTP reports](cdn-advanced-http-reports.md)  |  | | |**&#x2713;** |
 | [Real-time stats](cdn-real-time-stats.md)  |  | | |**&#x2713;** |
 | [Edge node performance](cdn-edge-performance.md)  |  | | |**&#x2713;** |
 | [Real-time alerts](cdn-real-time-alerts.md)  |  | | |**&#x2713;** |
 ||||
-| **Ease of use** | **Standard Microsoft** | **Standard Akamai** | **Standard Verizon** | **Premium Verizon** |
+| **Ease of use** | **Standard Microsoft** | **Standard Akamai** | **Standard Edgio** | **Premium Edgio** |
 | Easy integration with Azure services, such as [Storage](cdn-create-a-storage-account-with-cdn.md), [Web Apps](cdn-add-to-web-app.md), and [Media Services](/azure/media-services/previous/media-services-portal-manage-streaming-endpoints)  | **&#x2713;** |**&#x2713;** |**&#x2713;** |**&#x2713;** |
 | Management via [REST API](/rest/api/cdn/), [.NET](cdn-app-dev-net.md), [Node.js](cdn-app-dev-node.md), or [PowerShell](cdn-manage-powershell.md)  | **&#x2713;** |**&#x2713;** |**&#x2713;** |**&#x2713;** |
 | [Compression MIME types](./cdn-improve-performance.md)  |Configurable |Configurable |Configurable  |Configurable  |
@@ -74,10 +74,10 @@ The following table compares the features available with each product.
 
 ## Migration
 
-For information about migrating an **Azure CDN Standard from Verizon** profile to **Azure CDN Premium from Verizon**, see [Migrate an Azure CDN profile from Standard Verizon to Premium Verizon](cdn-migrate.md).
+For information about migrating an **Azure CDN Standard from Edgio** profile to **Azure CDN Premium from Edgio**, see [Migrate an Azure CDN profile from Standard Edgio to Premium Edgio](cdn-migrate.md).
 
 > [!NOTE]
-> There is an upgrade path from Standard Verizon to Premium Verizon, there is no conversion mechanism between other products at this time.
+> There is an upgrade path from Standard Edgio to Premium Edgio, there is no conversion mechanism between other products at this time.
 
 ## Next steps
 


### PR DESCRIPTION
Customers will be confused because the pricing page correctly refers to Edgio, but these docs refer to "Verizon", the old name for this service.